### PR TITLE
nftables - avoid payload extract marking bulk ports

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -460,8 +460,8 @@ table inet dscptag {
     }
 
     chain mark_bulk {
+        ip dscp set cs1 return
         ip6 dscp set cs1
-        ip dscp set cs1
     }
 
     chain dscptag {

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -285,8 +285,8 @@ fi
 # Check if UDPBULKPORT is set
 if [ -n "$UDPBULKPORT" ]; then
     udpbulkport_rules="\
-meta l4proto udp ct original proto-src \$udpbulkport counter jump mark_bulk
-        meta l4proto udp ct original proto-dst \$udpbulkport counter jump mark_bulk"
+meta l4proto udp ct original proto-src \$udpbulkport counter jump mark_cs1
+        meta l4proto udp ct original proto-dst \$udpbulkport counter jump mark_cs1"
 else
     udpbulkport_rules="# UDP Bulk Port rules disabled, no ports defined."
 fi
@@ -294,7 +294,7 @@ fi
 # Check if TCPBULKPORT is set
 if [ -n "$TCPBULKPORT" ]; then
     tcpbulkport_rules="\
-meta l4proto tcp ct original proto-dst \$tcpbulkport counter jump mark_bulk"
+meta l4proto tcp ct original proto-dst \$tcpbulkport counter jump mark_cs1"
 else
     tcpbulkport_rules="# UDP Bulk Port rules disabled, no ports defined."
 fi
@@ -458,7 +458,7 @@ table inet dscptag {
         numgen random mod 100 < 50 drop
     }
 
-    chain mark_bulk {
+    chain mark_cs1 {
         ip dscp set cs1 return
         ip6 dscp set cs1
     }

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -294,8 +294,7 @@ fi
 # Check if TCPBULKPORT is set
 if [ -n "$TCPBULKPORT" ]; then
     tcpbulkport_rules="\
-meta l4proto tcp ct original proto-src \$tcpbulkport counter jump mark_bulk
-        meta l4proto tcp ct original proto-dst \$tcpbulkport counter jump mark_bulk"
+meta l4proto tcp ct original proto-dst \$tcpbulkport counter jump mark_bulk"
 else
     tcpbulkport_rules="# UDP Bulk Port rules disabled, no ports defined."
 fi

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -285,10 +285,8 @@ fi
 # Check if UDPBULKPORT is set
 if [ -n "$UDPBULKPORT" ]; then
     udpbulkport_rules="\
-ip protocol udp udp sport \$udpbulkport ip dscp set cs1 counter
-        ip6 nexthdr udp udp sport \$udpbulkport ip6 dscp set cs1 counter
-        ip protocol udp udp dport \$udpbulkport ip dscp set cs1 counter
-        ip6 nexthdr udp udp dport \$udpbulkport ip6 dscp set cs1 counter"
+meta l4proto udp ct original proto-src \$udpbulkport counter jump mark_bulk
+        meta l4proto udp ct original proto-dst \$udpbulkport counter jump mark_bulk"
 else
     udpbulkport_rules="# UDP Bulk Port rules disabled, no ports defined."
 fi
@@ -296,10 +294,8 @@ fi
 # Check if TCPBULKPORT is set
 if [ -n "$TCPBULKPORT" ]; then
     tcpbulkport_rules="\
-ip protocol tcp tcp sport \$tcpbulkport ip dscp set cs1 counter
-        ip6 nexthdr tcp tcp sport \$tcpbulkport ip6 dscp set cs1 counter
-        ip protocol tcp tcp dport \$tcpbulkport ip dscp set cs1 counter
-        ip6 nexthdr tcp tcp dport \$tcpbulkport ip6 dscp set cs1 counter"
+meta l4proto tcp ct original proto-src \$tcpbulkport counter jump mark_bulk
+        meta l4proto tcp ct original proto-dst \$tcpbulkport counter jump mark_bulk"
 else
     tcpbulkport_rules="# UDP Bulk Port rules disabled, no ports defined."
 fi
@@ -463,6 +459,10 @@ table inet dscptag {
         numgen random mod 100 < 50 drop
     }
 
+    chain mark_bulk {
+        ip6 dscp set cs1
+        ip dscp set cs1
+    }
 
     chain dscptag {
         type filter hook $NFT_HOOK priority $NFT_PRIORITY; policy accept;


### PR DESCRIPTION
Use conntrack port markers in place of payload extract
 in addition examine l4+port before diverging ip4/ip6 for dscp

Signed-off-by: Andris PE <neandris@gmail.com>