### PR TITLE
Avoid all payload extracts for vidconf marking

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -307,7 +307,7 @@ fi
 # Check if VIDCONFPORTS is set
 if [ -n "$VIDCONFPORTS" ]; then
     vidconfports_rules="\
-meta l4proto udp ct original proto-dst \$vidconfports counter jump mark_video"
+meta l4proto udp ct original proto-dst \$vidconfports counter jump mark_af42"
 else
     vidconfports_rules="# VIDCONFPORTS Port rules disabled, no ports defined."
 fi
@@ -462,7 +462,7 @@ table inet dscptag {
         numgen random mod 100 < 50 drop
     }
 
-    chain mark_video {
+    chain mark_af42 {
         ip dscp set af42 return
         ip6 dscp set af42
     }

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -307,7 +307,7 @@ fi
 # Check if VIDCONFPORTS is set
 if [ -n "$VIDCONFPORTS" ]; then
     vidconfports_rules="\
-udp dport \$vidconfports counter jump mark_video"
+meta l4proto udp ct original proto-dst \$vidconfports counter jump mark_video"
 else
     vidconfports_rules="# VIDCONFPORTS Port rules disabled, no ports defined."
 fi

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -307,8 +307,7 @@ fi
 # Check if VIDCONFPORTS is set
 if [ -n "$VIDCONFPORTS" ]; then
     vidconfports_rules="\
-ip protocol udp udp dport \$vidconfports ip dscp set af42 counter
-        ip6 nexthdr udp udp dport \$vidconfports ip6 dscp set af42 counter"
+udp dport \$vidconfports counter jump mark_video"
 else
     vidconfports_rules="# VIDCONFPORTS Port rules disabled, no ports defined."
 fi
@@ -463,6 +462,10 @@ table inet dscptag {
         numgen random mod 100 < 50 drop
     }
 
+    chain mark_video {
+        ip dscp set af42 return
+        ip6 dscp set af42
+    }
 
     chain dscptag {
         type filter hook $NFT_HOOK priority $NFT_PRIORITY; policy accept;


### PR DESCRIPTION
Remove unnecessary pre-filter and avoid extracting l4poroto from payload.
Run l4+port check first,
then branch nfproto for dscp
quick return chain after ip4 to avoid extra impossible ip6 match in common case

Signed-off-by: Andris PE <neandris@gmail.com>