### PR TITLE
Unify tcp upgrade rules into one

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -353,8 +353,7 @@ fi
 # Check if TCP upgrade for slow connections should be applied
 if [ "$TCP_UPGRADE_ENABLED" -eq 1 ]; then
     tcp_upgrade_rules="
-meta l4proto tcp add @slowtcp {ct id limit rate 150/second burst 150 packets } ip dscp set af42 counter
-        meta l4proto tcp add @slowtcp {ct id limit rate 150/second burst 150 packets} ip6 dscp set af42 counter"
+meta l4proto tcp add @slowtcp {ct id limit rate 150/second burst 150 packets } counter jump mark_af42"
 else
     tcp_upgrade_rules="# TCP upgrade for slow connections is disabled"
 fi


### PR DESCRIPTION
ditto, match l4proto before diverging v4/v6, one rule less in main flow for packets that dont match.

Signed-off-by: Andris PE <neandris@gmail.com>