### PR TITLE
Do not clear bulk markings when down-prioritizing

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -457,12 +457,12 @@ table inet dscptag {
     }
 
     chain mark_500ms {
-        ip dscp < cs4 ip dscp set cs0 counter return
-        ip6 dscp < cs4 ip6 dscp set cs0 counter
+        ip dscp { 0x01-0x07, 0x09-0x1f } ip dscp set cs0 counter return
+        ip6 dscp { 0x01-0x07, 0x09-0x1f } ip6 dscp set cs0 counter
     }
     chain mark_10s {
-        ip dscp < cs4 ip dscp set cs1 counter return
-        ip6 dscp < cs4 ip6 dscp set cs1 counter
+        ip dscp { 0x00-0x07, 0x09-0x1f } ip dscp set cs1 counter return
+        ip6 dscp { 0x00-0x07, 0x09-0x1f } ip6 dscp set cs1 counter
     }
     
     chain mark_cs1 {

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -457,12 +457,12 @@ table inet dscptag {
     }
 
     chain mark_500ms {
-        ip dscp { 0x01-0x07, 0x09-0x1f } ip dscp set cs0 counter return
-        ip6 dscp { 0x01-0x07, 0x09-0x1f } ip6 dscp set cs0 counter
+        ip dscp < cs4 ip dscp set cs0 counter return
+        ip6 dscp < cs4 ip6 dscp set cs0 counter
     }
     chain mark_10s {
-        ip dscp { 0x00-0x07, 0x09-0x1f } ip dscp set cs1 counter return
-        ip6 dscp { 0x00-0x07, 0x09-0x1f } ip6 dscp set cs1 counter
+        ip dscp < cs4 ip dscp set cs1 counter return
+        ip6 dscp < cs4 ip6 dscp set cs1 counter
     }
     
     chain mark_cs1 {

--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -457,12 +457,12 @@ table inet dscptag {
     }
 
     chain mark_500ms {
-        ip dscp { 0x01-0x07, 0x09-0x1f } ip dscp set cs0 counter return
-        ip6 dscp { 0x01-0x07, 0x09-0x1f } ip6 dscp set cs0 counter
+        ip dscp < cs4 ip dscp != cs1 ip dscp set cs0 counter return
+        ip6 dscp < cs4 ip6 dscp != cs1 ip6 dscp set cs0 counter
     }
     chain mark_10s {
-        ip dscp { 0x00-0x07, 0x09-0x1f } ip dscp set cs1 counter return
-        ip6 dscp { 0x00-0x07, 0x09-0x1f } ip6 dscp set cs1 counter
+        ip dscp < cs4 ip dscp set cs1 counter return
+        ip6 dscp < cs4 ip6 dscp set cs1 counter
     }
     
     chain mark_cs1 {


### PR DESCRIPTION
first 500ms wrongly upgrades already bulk tcp connections

simplistic filter would be 
```
ip dscp lt cs4 ip dscp ne cs1
```

optimize that to range with single payload extract

since we are extracting payload anyway also avoid forcing unchanged value on packets.