### PR TITLE
Simplify tcp ack syntax

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -274,10 +274,10 @@ DYNAMIC_RULES=$(generate_dynamic_nft_rules)
 # Check if ACKRATE is greater than 0
 if [ "$ACKRATE" -gt 0 ]; then
     ack_rules="\
-meta length < 100 tcp flags & ack == ack add @xfst4ack {ct id . ct direction limit rate over ${XFSTACKRATE}/second} counter jump drop995
-        meta length < 100 tcp flags & ack == ack add @fast4ack {ct id . ct direction limit rate over ${FASTACKRATE}/second} counter jump drop95
-        meta length < 100 tcp flags & ack == ack add @med4ack {ct id . ct direction limit rate over ${MEDACKRATE}/second} counter jump drop50
-        meta length < 100 tcp flags & ack == ack add @slow4ack {ct id . ct direction limit rate over ${SLOWACKRATE}/second} counter jump drop50"
+meta length < 100 tcp flags ack add @xfst4ack {ct id . ct direction limit rate over ${XFSTACKRATE}/second} counter jump drop995
+        meta length < 100 tcp flags ack add @fast4ack {ct id . ct direction limit rate over ${FASTACKRATE}/second} counter jump drop95
+        meta length < 100 tcp flags ack add @med4ack {ct id . ct direction limit rate over ${MEDACKRATE}/second} counter jump drop50
+        meta length < 100 tcp flags ack add @slow4ack {ct id . ct direction limit rate over ${SLOWACKRATE}/second} counter jump drop50"
 else
     ack_rules="# ACK rate regulation disabled as ACKRATE=0 or not set."
 fi


### PR DESCRIPTION
No change in bytecode length, just amazing negation in place, resulting in shorter expression in text form.

Signed-off-by: Andris PE <neandris@gmail.com>