### PR TITLE
Unify tcp upgrade rules into one

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -353,8 +353,7 @@ fi
 # Check if TCP upgrade for slow connections should be applied
 if [ "$TCP_UPGRADE_ENABLED" -eq 1 ]; then
     tcp_upgrade_rules="
-meta l4proto tcp add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets } ip dscp set af42 counter
-        meta l4proto tcp add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets} ip6 dscp set af42 counter"
+meta l4proto tcp add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets } counter jump mark_af42
 else
     tcp_upgrade_rules="# TCP upgrade for slow connections is disabled"
 fi


### PR DESCRIPTION
Was pr15
Reuse af42 marking chain to get rid of nearly duplicate rule, accidentally lost in pr20

Signed-off-by: Andris PE <neandris@gmails.com>