### PR TITLE
Avoid altering loopback packets

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -482,7 +482,7 @@ table inet dscptag {
     chain dscptag {
         type filter hook $NFT_HOOK priority $NFT_PRIORITY; policy accept;
 
-        
+        iif "lo" accept
         $(if [ "$ROOT_QDISC" = "hfsc" ] && [ "$WASHDSCPDOWN" -eq 1 ]; then
             echo "# wash all the DSCP on ingress ... "
             echo "        counter jump mark_cs0"


### PR DESCRIPTION
Necessary only if hook not forward.
 Per-connection shaper-droppers should not change local non-game traffic.
This is very light - compare meta-integer to value, but can be made conditional on hook neq forward.
