### PR TITLE
Do not save dscp to ctmark when state not known

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -740,8 +740,8 @@ ${DYNAMIC_RULES}
         meta priority set ip6 dscp map @priomap counter
 
         # Store DSCP in conntrack for restoration on ingress
-        ct mark set ip dscp or 128 counter
-        ct mark set ip6 dscp or 128 counter
+        ct id != 0 ct mark set ip dscp or 128 counter
+        ct id != 0 ct mark set ip6 dscp or 128 counter
 
         $(if [ "$ROOT_QDISC" = "hfsc" ] && [ "$WASHDSCPUP" -eq 1 ]; then
             echo "# wash all DSCP on egress ... "


### PR DESCRIPTION
Do not save dscp yo null state so that tcinfo stops marking ingress packets failing to classify with random priorities

Covers certain part of 2 and 3 in https://forum.openwrt.org/t/qosmate-yet-another-quality-of-service-tool-for-openwrt/207614/1720

Signed-off-by: Andris PE <neandris@gmail.com>