### PR TITLE
Work around nftable specifics

### DIFF
--- a/etc/qosmate.sh
+++ b/etc/qosmate.sh
@@ -589,8 +589,8 @@ fi
 # Check if TCP upgrade for slow connections should be applied
 if [ "$TCP_UPGRADE_ENABLED" -eq 1 ]; then
     tcp_upgrade_rules="
-meta l4proto tcp ip dscp != cs1 add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets } ip dscp set af42 meta mark set meta mark or 64 counter
-        meta l4proto tcp ip6 dscp != cs1 add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets} ip6 dscp set af42 meta mark set meta mark or 64 counter"
+meta nfproto ipv4 meta l4proto tcp ip dscp != cs1 add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets } ip dscp set af42 meta mark set meta mark or 64 counter
+        meta nfproto ipv6 meta l4proto tcp ip6 dscp != cs1 add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets} ip6 dscp set af42 meta mark set meta mark or 64 counter"
 else
     tcp_upgrade_rules="# TCP upgrade for slow connections is disabled"
 fi
@@ -787,8 +787,8 @@ ${DYNAMIC_RULES}
         meta priority set ip6 dscp map @priomap counter
 
         # Store DSCP in conntrack for restoration on ingress only if modified by QoSmate
-        ct id != 0 meta mark & 64 != 0 ct mark set ip dscp or 128 counter
-        ct id != 0 meta mark & 64 != 0 ct mark set ip6 dscp or 128 counter
+        meta nfproto ipv4 ct id != 0 meta mark & 64 != 0 ct mark set ip dscp or 128 counter
+        meta nfproto ipv6 ct id != 0 meta mark & 64 != 0 ct mark set ip6 dscp or 128 counter
 
         $(if { [ "$ROOT_QDISC" = "hfsc" ] || [ "$ROOT_QDISC" = "hybrid" ]; } && [ "$WASHDSCPUP" -eq 1 ]; then
             echo "# wash all DSCP on egress ... "


### PR DESCRIPTION
Both rules emit meta nfproto bytecode before ipX dscp, not at start Add explicit nfproto at start so that line pair brasnches in efficient way (skipping useless processing in front of v4 branch in v6 packet case.
list display omits nfproto and re-applied puts it in unintendrd place. 1st piece was missed by me
2nd was accidentally introduced in 12b8367ef0e4bd6a250aeac8ac414fc02ac7940b

Signed-off-by: Andris PE <neandris@gmail.com>
