### PR TITLE
Set up QoSmate package for OpenWrt build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,15 +1166,17 @@ Note: Make sure to review and adjust the default configuration as needed for you
 ## Building qosmate and Luci-app-qosmate Packages for OpenWrt
 
 1. Navigate to Your OpenWrt Buildroot Directory:
-`cd /path/to/your/openwrt
-`
+```bash
+cd /path/to/your/openwrt
+```
 2. Clone the QoSmate Package:
-`mkdir -p package/qosmate
-git clone https://github.com/hudra0/qosmate.git package/qosmate
-`
+```bash
+mkdir -p package/qosmate && git clone https://github.com/hudra0/qosmate.git package/qosmate
+```
 3. Clone the LuCI QoSmate Package:
-`mkdir -p package/luci-app-qosmate
-git clone https://github.com/hudra0/luci-app-qosmate.git package/luci-app-qosmate`
+```bash
+mkdir -p package/luci-app-qosmate && git clone https://github.com/hudra0/luci-app-qosmate.git package/luci-app-qosmate
+```
 
 ## QoSmate Traffic Shaping: HFSC, HTB and CAKE
 


### PR DESCRIPTION
- Add && between mkdir and git clone commands
- Fixes issue where git clone wouldn't execute due to missing operator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves README build instructions for OpenWrt packaging.
> 
> - Converts inline/backticked command snippets to fenced `bash` code blocks for steps 1–3
> - Chains `mkdir` and `git clone` with `&&` for `qosmate` and `luci-app-qosmate` to ensure proper execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e30e151d2af19a7e2d399cb40e3fb5c51af90e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->